### PR TITLE
change getEntityManager to getManager

### DIFF
--- a/Controller/SortableTreeController.php
+++ b/Controller/SortableTreeController.php
@@ -16,7 +16,7 @@ class SortableTreeController extends CRUDController
 		$id = $object->getId();
 		
     	$repo = $this->getDoctrine()
-    		->getEntityManager()
+    		->getManager()
     		->getRepository($entity);
 		
     	$subject = $repo->findOneById($id);
@@ -35,7 +35,7 @@ class SortableTreeController extends CRUDController
 		$id = $object->getId();
 		
     	$repo = $this->getDoctrine()
-    		->getEntityManager()
+    		->getManager()
     		->getRepository($entity);
 		
     	$subject = $repo->findOneById($id);


### PR DESCRIPTION
This change is made to avoid displaying deprecation message when moving items (it does appear before redirect for some reason).
